### PR TITLE
MouseoverCast-Fix for non-SuperWoW users

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -91,13 +91,13 @@ function CleveRoids.TestForActiveAction(actions)
 
             -- nampower range check
             if IsSpellInRange then
-				local unit = actions.active.conditionals and actions.active.conditionals.target or "target"
-				if unit == "focus" then
-					actions.active.inRange = IsSpellInRange(actions.active.action, pfUI.uf.focus.label .. pfUI.uf.focus.id)
-				elseif UnitExists(unit) then
-					actions.active.inRange = IsSpellInRange(actions.active.action, unit)
-				end
-			end
+            	local unit = actions.active.conditionals and actions.active.conditionals.target or "target"
+            	if unit == "focus" and pfUI then
+            		actions.active.inRange = IsSpellInRange(actions.active.action, pfUI.uf.focus.id)
+            	elseif UnitExists(unit) then
+            		actions.active.inRange = IsSpellInRange(actions.active.action, unit)
+            	end
+            end
 
             actions.active.oom = (UnitMana("player") < actions.active.spell.cost)
 

--- a/Extensions/Mouseover/GameTooltip.lua
+++ b/Extensions/Mouseover/GameTooltip.lua
@@ -4,28 +4,30 @@
 ]]
 local _G = _G or getfenv(0)
 local CleveRoids = _G.CleveRoids or {}
-
 local Extension = CleveRoids.RegisterExtension("GameTooltipMouseover")
 
 function Extension.SetUnit(_, unit)
-    -- When GameTooltip is shown for a unit, set the game's mouseover
-    if SetMouseoverUnit then
-        SetMouseoverUnit(unit)
-    end
+	-- When GameTooltip is shown for a unit, set the game's mouseover
+	if CleveRoids.hasSuperwow and SetMouseoverUnit then
+		SetMouseoverUnit(unit)
+	else 
+		CleveRoids.mouseoverUnit = unit
+	end
 end
-
 
 function Extension.OnClose()
-    -- When GameTooltip is hidden, clear the game's mouseover
-    if SetMouseoverUnit then
-        SetMouseoverUnit()
-    end
-end
+	-- When GameTooltip is hidden, clear the game's mouseover
+	if CleveRoids.hasSuperwow and SetMouseoverUnit then
+		SetMouseoverUnit()
+	else 
+		CleveRoids.mouseoverUnit = unit
+	end
+end	
 
 function Extension.OnLoad()
-    Extension.HookMethod(_G["GameTooltip"], "SetUnit", "SetUnit")
-    Extension.HookMethod(_G["GameTooltip"], "Hide", "OnClose")
-    Extension.HookMethod(_G["GameTooltip"], "FadeOut", "OnClose")
+	Extension.HookMethod(_G["GameTooltip"], "SetUnit", "SetUnit")
+	Extension.HookMethod(_G["GameTooltip"], "Hide", "OnClose")
+	Extension.HookMethod(_G["GameTooltip"], "FadeOut", "OnClose")
 end
 
 _G["CleveRoids"] = CleveRoids


### PR DESCRIPTION
added check if superwow is installed, if so it uses new 1.14 mouseover function - otherwise normal 1.13 function.

Fixes #13 